### PR TITLE
feat: Xdebugの環境構築を行いました。

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,48 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Listen for Xdebug",
+      "type": "php",
+      "request": "launch",
+      "port": 9003,
+      "pathMappings": {
+        "/var/www/html": "${workspaceRoot}"
+      }
+    },
+    {
+      "name": "Launch currently open script",
+      "type": "php",
+      "request": "launch",
+      "program": "${file}",
+      "cwd": "${fileDirname}",
+      "port": 0,
+      "runtimeArgs": [
+        "-dxdebug.start_with_request=yes"
+      ],
+      "env": {
+        "XDEBUG_MODE": "debug,develop",
+        "XDEBUG_CONFIG": "client_port=${port}"
+      }
+    },
+    {
+      "name": "Launch Built-in web server",
+      "type": "php",
+      "request": "launch",
+      "runtimeArgs": [
+        "-dxdebug.mode=debug",
+        "-dxdebug.start_with_request=yes",
+        "-S",
+        "localhost:0"
+      ],
+      "program": "",
+      "cwd": "${workspaceRoot}",
+      "port": 9003,
+      "serverReadyAction": {
+        "pattern": "Development Server \\(http://localhost:([0-9]+)\\) started",
+        "uriFormat": "http://localhost:%s",
+        "action": "openExternally"
+      }
+    }
+  ]
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,9 @@
 FROM php:8.2-apache
 
+# Xdebug 環境構築
+RUN pecl install xdebug && \
+  docker-php-ext-enable xdebug
+
 # Docker 公式の Composer イメージ を使用
 COPY --from=composer:latest /usr/bin/composer /usr/bin/composer
 

--- a/README.md
+++ b/README.md
@@ -39,5 +39,5 @@ composer install
 6. index.php を PSR-12 に従って静的解析するコマンドです。
 
 ```shell
-./vendor/bin/phpcs --standard=PSR12 ./index.php
+./vendor/bin/phpcs --standard=PSR12 ./src/php/pages/index.php
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,7 @@ services:
     build: ./
     container_name: php
     volumes:
+      - ./php.ini:/usr/local/etc/php/php.ini
       - ./:/var/www/html
     ports:
       - 9080:80

--- a/php.ini
+++ b/php.ini
@@ -1,0 +1,7 @@
+[xdebug]
+xdebug.client_host = host.docker.internal
+xdebug.mode = debug
+xdebug.start_with_request = yes
+xdebug.discover_client_host = 0
+xdebug.remote_handler = "dbgp"
+xdebug.client_port = 9003


### PR DESCRIPTION
# 手順
1. feature/docker-setupブランチに入ってください。
2.  VSCodeで拡張機能「PHP Debug」をインストール
3. docker-compose up -d を実行
4. ./src/php/pages/index.phpにブレイクポイントを設定
5. http://localhost:9080/src/php/pages/にアクセスしたらデバック実行ができるはずです。

ご教示頂いたRemote Developmentではうまく動作しませんでした。
コンテナ内にはXdebugを入れていますので、それぞれの環境で個別に構築する必要があるかもしれません。